### PR TITLE
Updates to run state machine

### DIFF
--- a/bpod_core/bpod.py
+++ b/bpod_core/bpod.py
@@ -4,6 +4,7 @@ import logging
 import re
 import struct
 import time
+import inspect
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import NamedTuple
@@ -119,6 +120,8 @@ class Bpod:
     """List of event names."""
     output_actions: list[str]
     """List of output actions."""
+    soft_code_handler: str
+    """Name of soft code handler function in user protocol workspace."""
 
     @validate_call
     def __init__(self, port: str | None = None, serial_number: str | None = None):
@@ -127,6 +130,7 @@ class Bpod:
         # initialize members
         self.event_names = []
         self.output_actions = []
+        self.soft_code_handler = None
 
         # identify Bpod by port or serial number
         port, self._serial_number = self._identify_bpod(port, serial_number)
@@ -964,6 +968,10 @@ class Bpod:
 
     def run_state_machine(self):
         """Temporary run method for debugging purposes."""
+        # Resolve soft code function
+        caller_globals = inspect.stack()[1].frame.f_globals
+        soft_code_func = caller_globals.get(self.soft_code_handler)
+
         self.serial0.reset_input_buffer()
         self.serial0.write(b'R')
         if self._state_matrix_sent:
@@ -973,6 +981,7 @@ class Bpod:
                     'The last state machine sent was not confirmed by the Bpod'
                 )
             self._state_matrix_sent = False
+        logger.debug('') # Visual separation in log before next trial start
         logger.debug('*** Trial Start ***')
         t0 = self.serial0.read_struct('<Q')[0]
         logger.debug(f'Trial start time: " {t0 / 1e6} s')
@@ -982,7 +991,7 @@ class Bpod:
                 time.sleep(5e-6)
             op1, op2 = self.serial0.read_struct('<2B')
             match op1:
-                case 1:
+                case 1: # Receive event(s)
                     event_data = self.serial0.read_struct(f'<{op2}B I')
                     events = event_data[:op2]
                     timestamp = event_data[op2]
@@ -997,10 +1006,14 @@ class Bpod:
                             end_timestamp_us = (struct.unpack('<Q', end_timestamps[-8:])[0]) / 1000000
                             logger.debug(f"Trial-End: {end_timestamp_us}s")
                             logger.debug(f"Trial Duration: {end_timestamp_cycles}s")
-                            logger.debug('')
                             running = False
-                case 2:
+                case 2: # Handle soft code by calling the designated soft code function in the user workspace
                     logger.debug(f'soft-code {op2}')
+                    if callable(soft_code_func):
+                        logger.debug(f"Calling soft-code handler: {self.soft_code_handler}")
+                        soft_code_func(op2)
+                    else:
+                        raise RuntimeError(f"Soft-Code Handler function '{self.soft_code_handler}' not found or is not callable.")
                 case _:
                     raise RuntimeError(f'Unknown opcode: {op1}')
 

--- a/bpod_core/bpod.py
+++ b/bpod_core/bpod.py
@@ -102,6 +102,7 @@ class Bpod:
 
     _version: VersionInfo
     _hardware: HardwareConfiguration
+    _state_matrix_sent: False # TODO: Replace this with a subfield of _status
     serial0: ExtendedSerial
     """Primary serial device for communication with the Bpod."""
     serial1: ExtendedSerial | None = None
@@ -959,17 +960,22 @@ class Bpod:
         self.serial0.write_struct(
             f'<c2?H{n_bytes}s', b'C', run_asap, use_back_op, n_bytes, byte_array
         )
+        self._state_matrix_sent = True
 
     def run_state_machine(self):
         """Temporary run method for debugging purposes."""
         self.serial0.reset_input_buffer()
-        if not self.serial0.query(b'R'):
-            raise RuntimeError(
-                'The last state machine sent was not confirmed by the Bpod'
-            )
-        logger.debug('Running state machine ...')
+        self.serial0.write(b'R')
+        if self._state_matrix_sent:
+            confirmed = self.serial0.read(1)
+            if confirmed[0] != 1:
+                raise RuntimeError(
+                    'The last state machine sent was not confirmed by the Bpod'
+                )
+            self._state_matrix_sent = False
+        logger.debug('*** Trial Start ***')
         t0 = self.serial0.read_struct('<Q')[0]
-        logger.debug(f'Starting trial at {t0 / 1e6} s')
+        logger.debug(f'Trial start time: " {t0 / 1e6} s')
         running = True
         while running:
             if self.serial0.in_waiting < 2:
@@ -977,13 +983,21 @@ class Bpod:
             op1, op2 = self.serial0.read_struct('<2B')
             match op1:
                 case 1:
-                    events = self.serial0.read_struct(f'<{op2}B')
-                    timestamp = self.serial0.read_struct('<I')[0]
+                    event_data = self.serial0.read_struct(f'<{op2}B I')
+                    events = event_data[:op2]
+                    timestamp = event_data[op2]
                     for event in events:
                         event_name = 'exit' if event == 255 else self.event_names[event]
-                        timestamp_s = timestamp * self._hardware.cycle_frequency / 1e5
-                        logger.debug(f'{timestamp_s:0.1f} ms - {event_name}')
+                        timestamp_s = timestamp * self._hardware.cycle_frequency / 1e8
+                        logger.debug(f'Event: {event_name} - {timestamp_s:0.1f}s')
                         if event == 255:
+                            end_timestamps = self.serial0.read(12)
+                            end_timestamp_cycles = (struct.unpack('<I', end_timestamps[:4])[
+                                0]) / self._hardware.cycle_frequency
+                            end_timestamp_us = (struct.unpack('<Q', end_timestamps[-8:])[0]) / 1000000
+                            logger.debug(f"Trial-End: {end_timestamp_us}s")
+                            logger.debug(f"Trial Duration: {end_timestamp_cycles}s")
+                            logger.debug('')
                             running = False
                 case 2:
                     logger.debug(f'soft-code {op2}')


### PR DESCRIPTION
Improvements to run_state_machine() function of Bpod class:
1. Fixed a bug causing a crash if each call to run_state_machine() was not preceded by a call to send_state_machine()
2. Added support for reading the trial-end timestamp
3. Improved logging output for human-readability
4. Improved efficiency by reducing calls to serial.read()
5. Added support for user-defined soft code handler functions (defined in the calling workspace of run_state_machine())

Note: New properties Bpod.soft_code_handler and Bpod._state_matrix_sent may need to be moved depending on how the Bpod class is ultimately organized
